### PR TITLE
build: fix odoriji in combineFuri()

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -59,11 +59,11 @@ export function basicFuri(word = '', reading = '') {
     reading.slice(stripOkurigana(reading, { matchKanji: word }).length),
   ];
 
-  const innerWordTokens = tokenize(removeExtraneousKana(word, bikago, okurigana));
+  const innerWordTokens = tokenizeWithOdoriji(removeExtraneousKana(word, bikago, okurigana));
   let innerReadingChars = removeExtraneousKana(reading, bikago, okurigana);
 
   const kanjiOddKanaEvenRegex = RegExp(
-    innerWordTokens.map((char) => (isKanji(char) ? '(.*)' : `(${char})`)).join('')
+    innerWordTokens.map((char) => ((isKanji(char) || char.includes('々')) ? '(.*)' : `(${char})`)).join('')
   );
 
   [, ...innerReadingChars] = innerReadingChars.match(kanjiOddKanaEvenRegex) || [];
@@ -80,6 +80,24 @@ export function basicFuri(word = '', reading = '') {
 
   return ret;
 }
+
+function tokenizeWithOdoriji(input) {
+  const tokenizedArray = tokenize(input);
+  // merge 々 with previous element
+  for (let i = 0; i < tokenizedArray.length; i += 1) {
+    if (tokenizedArray[i] === '々') {
+      if (i !== 0) {
+        tokenizedArray[i - 1] = tokenizedArray[i - 1] + tokenizedArray[i];
+        tokenizedArray[i] = '';
+      }
+    }
+  }
+  // remove empty element
+  const removedEmpty = tokenizedArray.filter((element) => element !== '');
+
+  return removedEmpty;
+}
+
 
 function removeExtraneousKana(str = '', leading = '', trailing = '') {
   return str.replace(RegExp(`^${leading}`), '').replace(RegExp(`${trailing}$`), '');

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -114,6 +114,13 @@ describe('combineFuri()', () => {
         ['がた', '型'],
       ]);
     });
+
+    it('odoriji', () => {
+      expect(combineFuri('人々が', 'ひとびとが')).toEqual([
+        ['ひとびと', '人々'],
+        ['', 'が'],
+      ]);
+    });
   });
 });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Add the functionality to deal with 踊り字.

<!-- Put an `x` in all the boxes that apply: -->

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (whitespace, formatting, missing semicolons, etc.)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Other… Please describe:

## Description

I found that if I have 踊り字 in the sentence like "々" of 人々, the combineFuri function is not working as expected.

After I read the code I found that the tokenize function(from wanakana) returns desired result if it is only a simple word.
For example, 人々 will return `[["ひとびと", "人々"]]`.

But 人々が returns `[["", "人"], ["", "々"], ["", "が"]]`. Seems like tokenize function tends to break 踊り字 apart when it is in a sentence.

So I create a simple function to detect if there are 踊り字 in the sentence.

I am not familiar with Pull Request flow and I am not very sure this is a general problem or not.
Just want to let you know the problem I encounter and how I fixed it. Maybe someone can deal with it in a better way.
Feel free to point out my mistake.

Finally, thank you for building this useful tool!

## How Has This Been Tested?

I add a test under your original utils.test.js. But I am not sure if I put it in the right place.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

## Checklist:

* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have read the [`contributing.md`](https://github.com/DJTB/hatsuon/blob/master/contributing.md).
